### PR TITLE
chore: remove `replace` directive from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,6 @@
         "friendsofphp/php-cs-fixer": "^2.17",
         "liip/rmt": "^1.5"
     },
-    "replace": {
-        "symfony/polyfill-php71": "*",
-        "symfony/polyfill-php70": "*",
-        "symfony/polyfill-php56": "*"
-    },
     "config": {
         "platform": {
             "php": "7.1.3"


### PR DESCRIPTION
Two packages with the same replace directives (e.g. plugin-quota and plugin-show-folder-size) cannot coexist according to composer.

```
whalehub@pdh:/opt/mailcow/data/web/roundcube# composer update --no-dev
Loading composer repositories with package information
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires jfcherng-roundcube/show-folder-size ~0.7.12 -> satisfiable by jfcherng-roundcube/show-folder-size[0.7.12].
    - Only one of these can be installed: symfony/polyfill-php70[v1.10.0, ..., v1.20.0], jfcherng-roundcube/quota[0.0.19], jfcherng-roundcube/show-folder-size[0.7.12]. [jfcherng-roundcube/quota, jfcherng-roundcube/show-folder-size] replace symfony/polyfill-php70 and thus cannot coexist with it.
    - Root composer.json requires jfcherng-roundcube/quota ~0.0.19 -> satisfiable by jfcherng-roundcube/quota[0.0.19].

Running update with --no-dev does not mean require-dev is ignored, it just means the packages will not be installed. If dev requirements are blocking the update you have to resolve those problems.
```